### PR TITLE
Increase mysql health-check retry from 3 to 5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       interval: 5s
       timeout: 3s
-      retries: 3
+      retries: 5
 
   phpmyadmin-dev:
     image: phpmyadmin:5.2.1


### PR DESCRIPTION
### Summary
1. Increased the amount of health-check retries for the MySQL service from 3 to 5

### Retrospective
MySQL has a really long start-up time. 15s while short, is on the edge for some systems and if any one system fails to start the stack in 15s, then it's already a problem.

30s seems like a good default If any system takes longer than 30s, a new solution should be looked at... Either choosing a new service or changing how the stack gets initialized.

### Testing
Skipping testing because it's a small change and will not cause any negative issues.