### PR TITLE
69 fix mac performance issues with docker stack

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -9,14 +9,6 @@ ARG DOCKER_UBUNTU_VERSION=latest
 
 # ========================== NODE STAGE ==========================
 FROM node:${DOCKER_NODE_VERSION} AS node
-# Copy all the required libraries for Node to run in a scratch container
-RUN mkdir -p /node-deps/lib/x86_64-linux-gnu \
-      /node-deps/usr/lib/x86_64-linux-gnu \
-      /node-deps/lib64 \
-    && ldd $(which node) \
-      | grep '=>' \
-      | awk '{ print $3 }' \
-      | xargs -I '{}' cp -v '{}' /node-deps'{}'
 
 
 # ========================== PACKAGES STAGE ==========================
@@ -95,7 +87,7 @@ RUN rm -rf build/ \
 
 
 # ========================== PRODUCTION STAGE ==========================
-FROM scratch AS production
+FROM node:${DOCKER_NODE_VERSION} AS production
 ARG NAME
 
 ARG WORKSPACE
@@ -105,11 +97,6 @@ ENV NODE_ENV=production
 
 # Copy Tini
 COPY --from=base /usr/bin/tini /usr/bin/tini
-
-# Copy necessary libraries to run Node in a scratch container
-COPY --from=node /node-deps/ /
-COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=node /lib64/ld-linux-x86-64.so.2 /lib64/
 
 # Copy build artifacts
 COPY --from=build --chown=${USER}:${USER} ${WORKSPACE}/${NAME}/dist ${WORKSPACE}/${NAME}/dist

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -8,7 +8,7 @@ ARG DOCKER_NODE_VERSION=latest
 ARG DOCKER_UBUNTU_VERSION=latest
 
 # ========================== NODE STAGE ==========================
-FROM --platform=linux/amd64 node:${DOCKER_NODE_VERSION} AS node
+FROM node:${DOCKER_NODE_VERSION} AS node
 # Copy all the required libraries for Node to run in a scratch container
 RUN mkdir -p /node-deps/lib/x86_64-linux-gnu \
       /node-deps/usr/lib/x86_64-linux-gnu \
@@ -20,7 +20,7 @@ RUN mkdir -p /node-deps/lib/x86_64-linux-gnu \
 
 
 # ========================== PACKAGES STAGE ==========================
-FROM --platform=linux/amd64 node:${DOCKER_NODE_VERSION} AS packages
+FROM node:${DOCKER_NODE_VERSION} AS packages
 ARG USER
 ARG WORKSPACE
 WORKDIR ${WORKSPACE}
@@ -32,7 +32,7 @@ RUN npm install -ws \
 
 
 # ========================== BASE STAGE ==========================
-FROM --platform=linux/amd64 ubuntu:${DOCKER_UBUNTU_VERSION} AS base
+FROM ubuntu:${DOCKER_UBUNTU_VERSION} AS base
 ARG NAME
 ARG WORKSPACE
 ARG USER
@@ -64,7 +64,7 @@ RUN npm install --omit=dev
 
 
 # ========================== DEVELOPMENT STAGE ==========================
-FROM --platform=linux/amd64 base AS development
+FROM base AS development
 ARG NAME
 
 ENV NODE_ENV=development
@@ -81,7 +81,7 @@ CMD ["npm", "run", "start:dev"]
 
 
 # ========================== BUILD STAGE ==========================
-FROM --platform=linux/amd64 base AS build
+FROM base AS build
 ARG NAME
 
 ARG WORKSPACE
@@ -95,7 +95,7 @@ RUN rm -rf build/ \
 
 
 # ========================== PRODUCTION STAGE ==========================
-FROM --platform=linux/amd64 scratch AS production
+FROM scratch AS production
 ARG NAME
 
 ARG WORKSPACE

--- a/docker/Dockerfile.package
+++ b/docker/Dockerfile.package
@@ -5,7 +5,7 @@ ARG WORKSPACE=/app
 ARG DOCKER_NODE_VERSION=latest
 
 # ========================== BUILDER STAGE ==========================
-FROM --platform=linux/amd64 node:${DOCKER_NODE_VERSION} AS builder
+FROM node:${DOCKER_NODE_VERSION} AS builder
 ARG NAME
 ARG WORKSPACE
 WORKDIR ${WORKSPACE}

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -9,10 +9,10 @@ ARG DOCKER_UBUNTU_VERSION=latest
 ARG DOCKER_NGINX_VERSION=latest
 
 # ========================== NODE STAGE ==========================
-FROM --platform=linux/amd64 node:${DOCKER_NODE_VERSION} AS node
+FROM node:${DOCKER_NODE_VERSION} AS node
 
 # ========================== PACKAGES STAGE ==========================
-FROM --platform=linux/amd64 node:${DOCKER_NODE_VERSION} AS packages
+FROM node:${DOCKER_NODE_VERSION} AS packages
 ARG USER
 ARG WORKSPACE
 WORKDIR ${WORKSPACE}
@@ -24,7 +24,7 @@ RUN npm install -ws \
 
 
 # ========================== BASE STAGE ==========================
-FROM --platform=linux/amd64 ubuntu:${DOCKER_UBUNTU_VERSION} AS base
+FROM ubuntu:${DOCKER_UBUNTU_VERSION} AS base
 ARG NAME
 ARG WORKSPACE
 ARG USER
@@ -56,7 +56,7 @@ RUN npm install --omit=dev
 
 
 # ========================== DEVELOPMENT STAGE ==========================
-FROM --platform=linux/amd64 base AS development
+FROM base AS development
 ARG NAME
 
 ENV NODE_ENV=development
@@ -73,7 +73,7 @@ CMD ["npm", "run", "start:dev"]
 
 
 # ========================== BUILD STAGE ==========================
-FROM --platform=linux/amd64 base AS build
+FROM base AS build
 ARG NAME
 
 ARG WORKSPACE
@@ -87,7 +87,7 @@ RUN rm -rf build/ \
 
 
 # ========================== PRODUCTION STAGE ==========================
-FROM --platform=linux/amd64 nginx:${DOCKER_NGINX_VERSION} AS production
+FROM nginx:${DOCKER_NGINX_VERSION} AS production
 ARG NAME
 ARG WORKSPACE
 


### PR DESCRIPTION
## Summary
This pull request introduces changes to Dockerfile which enforced using linux/amd64 as the desired platform, causing issues for Mac users who experienced MASSIVE performance degradation.

Changes were made to remove the forced desired platform and fix issues that occur because of the arm64 file system on Node, which lead to removing the scratch container and using Node as a base for production.

## Retrospective
Docker dev environments really need to be performance tested on all platforms before pushing. Failing to do causes massive frustration leading to less productivity.

Docker environments can already be so slow for some users, it's incredibly important to pay attention to this issue.

## Reviewer's Notes
No reviewers attached, reviewed live.

## Testing
Mac (m1,m2) users only

1. Run `make dev && make logs SERVICE=api-dev`
2. Observe time difference from `[nodemon] restarting service...` to server start
    - The time difference should be significantly lower than before these changes (~10s) -> (~3s)
