### PR TITLE
Remove walls of text from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,11 +4,16 @@ about: Report bugs to be squashed
 ---
 
 ### Description
+Brief summary of the bug encountered
 
 ### Expected Behaviour
+Description of what you expect to happen
 
 ### Actual Behaviour
+Description of what is actually happening
 
 ### System Info
+List of relevant system and program versions
 
 ### Steps to Reproduce
+List of steps to reproduce the bug

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,36 +4,11 @@ about: Report bugs to be squashed
 ---
 
 ## Description
-Provide a brief overview of the problem that needs to be addressed. Be specific about what is not working as expected and how it affects users or functionality within the project. This section should be concise but informative enough to give readers a clear understanding of the issue at hand.
-
-**Example**:
-The search functionality in our application is returning incorrect results when users input certain keywords.
 
 ## Expected Behaviour
-Describe how the application should behave under normal circumstances when using the affected feature or functionality. This will help others understand what is going wrong and how it differs from the expected behavior.
-
-**Example**:
-When users input a keyword into the search bar, they should receive a list of results that match their query accurately.
 
 ## Actual Behaviour
-Describe how the application is currently behaving when using the affected feature or functionality. This will help others understand what is going wrong and how it differs from the expected behavior.
-
-**Example**:
-When users input certain keywords into the search bar (e.g., "apple"), they receive a list of results that do not match their query accurately.
 
 ## System Info
-Provide any relevant information about your system setup that may help others reproduce the issue or understand its context better. This can include details about your operating system, browser version, device type, etc.
-
-**Example**:
-
-OS: MacOS 12.3.1 <br>
-Google Chrome: 99.0.4844.84
 
 ## Steps to Reproduce
-Provide a step-by-step guide on how to reproduce the issue. This will help others understand more clearly and provides a method to verify if the bug has been patched. If possible, include screenshots or other visual aids to illustrate your points.
-
-**Example**:
-1. Open our application in Google Chrome version 99.0.4844.84 on macOS 12.3.1.
-2. Navigate to the search page within the application.
-3. Input the keyword "apple" into the search bar.
-4. Observe that the results displayed do not accurately match the inputted keyword (e.g., results for "apples" instead of "apple").

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,12 +3,12 @@ name: Bug Report
 about: Report bugs to be squashed
 ---
 
-## Description
+### Description
 
-## Expected Behaviour
+### Expected Behaviour
 
-## Actual Behaviour
+### Actual Behaviour
 
-## System Info
+### System Info
 
-## Steps to Reproduce
+### Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -4,17 +4,5 @@ about: Describe a new task to be completed
 ---
 
 ## Description
-In this section, provide a brief overview of what needs to be added or changed in the project. Be specific enough about the functionality or feature that needs improvement or enhancement so that readers can understand what needs to be done. This section should be concise but informative enough to provide context for why this task is necessary.
-
-**Example**:
-We need to add a new feature that allows users to create custom dashboards by selecting specific widgets from a predefined list because it will enable users to tailor their experience to their specific needs and preferences.
 
 ## Solution
-Describe a high-level overview of what needs to be done to finish this task. Do not be too detailed here since more complex tasks will likely have a different final solution after working on the problem more closely.
-
-This section is **omitable** if there is no clear solution.
-
-**Example**:
-To implement this feature, we need to:
-1. Design a UI for creating custom dashboards by selecting widgets from a predefined list.
-2. Ensure that the dashboard remains responsive and functional across various screen sizes and devices.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -3,6 +3,6 @@ name: Task
 about: Describe a new task to be completed
 ---
 
-## Description
+### Description
 
-## Solution
+### Solution

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -4,5 +4,3 @@ about: Describe a new task to be completed
 ---
 
 ### Description
-
-### Solution

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -4,3 +4,4 @@ about: Describe a new task to be completed
 ---
 
 ### Description
+Explanation of a task that needs to be completed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-## Summary
+### Summary
 
-## Retrospective
+### Retrospective
 
-## Reviewer's Notes
+### Testing Notes
 
-## Testing
+### Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,11 @@
 ### Summary
+List of changes introduced by this pull request
 
 ### Retrospective
+Reflection of things learned or hardships encountered -- used as learning resource
 
 ### Testing Notes
+Notes for the reviewer of things to be aware of during testing
 
 ### Testing
+Comprehensive list of instructions to verify the changes are working as intended

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,7 @@
 ## Summary
-Provide a brief overview of the changes made in this pull request. Be specific about what has been added, removed, or modified within the project. This section should be concise but informative enough to give readers a clear understanding of what to expect when reviewing your changes.
-
-**Example**:
-This pull request adds a new feature that allows users to create custom dashboards by selecting specific widgets from a predefined list.
 
 ## Retrospective
-Share any insights or lessons learned during the development process that may be helpful for others to benefit from. This can include challenges faced, solutions found, or any other relevant information that can help improve future development efforts.
-
-This section is **omitable** if there is no relevant information.
-
-**Example**:
-During development, we encountered some difficulty in designing a UI for creating custom dashboards that was both intuitive and functional across various screen sizes and devices. However, after experimenting with different layout options and conducting user testing sessions, we were able to arrive at a design that met our requirements while also providing a positive user experience.
 
 ## Reviewer's Notes
-Provide any additional information that reviewers may need to know before testing your changes. This can include specific scenarios to test, known issues or limitations, or any other relevant details that can help ensure a thorough review process.
-
-This section is **omitable** if there is no relevant information.
-
-**Example**:
-When testing this feature, please ensure that you test it on multiple devices (e.g., desktop, tablet, mobile) to verify its responsiveness and functionality across various screen sizes.
-
-Additionally, please note that there is currently a known issue where users may experience slow performance when creating a dashboard with a large number of widgets; this will be addressed in a future update.
 
 ## Testing
-Provide clear instructions for reviewers to test your changes effectively. This can include specific scenarios to test, expected results, or any other relevant details that can help ensure a thorough review process. If possible, include screenshots or other visual aids to illustrate your points.
-
-**Example**:
-Test the creation of custom Dashboard using Widgets
-1. Open our application in a web browser on a desktop computer.
-2. Navigate to the "Create Dashboard" page within the application.
-3. Select a few widgets from the predefined list to add to your dashboard.
-4. Arrange the widgets on the canvas as desired.
-5. Save your dashboard by clicking the "Save Dashboard" button.


### PR DESCRIPTION
## Summary
Remove explanations from templates and save them into an [archive](https://github.com/Geek-Collectors-Network/geek-collectors-network/wiki/GitHub-Issue-Templates) in the wiki.
