### PR TITLE
83 add links to profile registration pages to reference opposite page

### DIFF
--- a/apps/frontend/src/components/LoginForm.tsx
+++ b/apps/frontend/src/components/LoginForm.tsx
@@ -1,22 +1,22 @@
-import { Button, FormControl, FormLabel, Input, VStack } from "@chakra-ui/react";
-import React from "react";
+import { Button, FormControl, FormLabel, Input, VStack } from '@chakra-ui/react';
+import React from 'react';
 
 function LoginForm() {
-    return (
-        <VStack spacing={8} w={{ base: "100%", md: "80%", lg: "50%" }}>
-            <FormControl id="email">
-                <FormLabel>Email</FormLabel>
-                <Input type="email" />
-            </FormControl>
-            <FormControl id="password">
-                <FormLabel>Password</FormLabel>
-                <Input type="password" />
-            </FormControl>
-            <Button bg={"brand.500"} color={"white"} _hover={{ bg: "brand.600" }} variant="solid" p={6}>
+  return (
+    <VStack spacing={8} w={{ base: '100%', md: '80%', lg: '50%' }}>
+      <FormControl id="email">
+        <FormLabel>Email</FormLabel>
+        <Input type="email" />
+      </FormControl>
+      <FormControl id="password">
+        <FormLabel>Password</FormLabel>
+        <Input type="password" />
+      </FormControl>
+      <Button bg={'brand.500'} color={'white'} _hover={{ bg: 'brand.600' }} variant="solid" p={6}>
                 LOGIN
-            </Button>
-        </VStack>
-    );
+      </Button>
+    </VStack>
+  );
 }
 
 export default LoginForm;

--- a/apps/frontend/src/components/LoginForm.tsx
+++ b/apps/frontend/src/components/LoginForm.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 function LoginForm() {
   return (
-    <VStack spacing={8} w={{ base: '100%', md: '80%', lg: '50%' }}>
+    <VStack gap={4} >
       <FormControl id="email">
         <FormLabel>Email</FormLabel>
         <Input type="email" />
@@ -12,8 +12,13 @@ function LoginForm() {
         <FormLabel>Password</FormLabel>
         <Input type="password" />
       </FormControl>
-      <Button bg={'brand.500'} color={'white'} _hover={{ bg: 'brand.600' }} variant="solid" p={6}>
-                LOGIN
+      <Button
+        bg={'brand.500'}
+        color={'white'}
+        _hover={{ bg: 'brand.600' }}
+        variant="solid" p={6}
+      >
+        LOGIN
       </Button>
     </VStack>
   );

--- a/apps/frontend/src/components/LoginPage.tsx
+++ b/apps/frontend/src/components/LoginPage.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {
+  Box,
+  Flex,
+  Heading,
+  VStack,
+} from "@chakra-ui/react";
+import { HamburgerIcon, ChevronLeftIcon } from "@chakra-ui/icons";
+
+interface LoginPageProps {
+  children: React.ReactNode;
+}
+
+// Add Header component created by Toco following rebase / merge
+function LoginPage( { children }: LoginPageProps) {
+  return (
+      <Box w={"100vw"} h={"100vh"} bg={"white"}>
+        <Box as="header" bg={"brand.500"} p={6} zIndex="sticky" top={0}>
+          <Flex justify="end" align="center">
+            <HamburgerIcon as="button" w={8} h={8} color="white" aria-label="Open Menu" />
+          </Flex>
+        </Box>
+        <VStack bg={"background.900"} px={10} pt={20}>
+          <Flex w={"100%"} align={"center"} justify={"start"} mb={10}>
+            <ChevronLeftIcon as="button" w={8} h={8} color="brand.500" aria-label="Go Back" />
+            <Heading size={"sm"} m={"auto"}>
+              Login
+            </Heading>
+          </Flex>
+          {/* Below is where the Login Form will be rendered. */}
+          {children}
+        </VStack>
+      </Box>
+  );
+}
+
+export default LoginPage;

--- a/apps/frontend/src/components/LoginPage.tsx
+++ b/apps/frontend/src/components/LoginPage.tsx
@@ -1,36 +1,36 @@
-import React from "react";
+import React from 'react';
 import {
   Box,
   Flex,
   Heading,
   VStack,
-} from "@chakra-ui/react";
-import { HamburgerIcon, ChevronLeftIcon } from "@chakra-ui/icons";
+} from '@chakra-ui/react';
+import { HamburgerIcon, ChevronLeftIcon } from '@chakra-ui/icons';
 
 interface LoginPageProps {
   formComponent: React.ReactNode;
 }
 
 // Add Header component created by Toco following rebase / merge
-function LoginPage( { formComponent }: LoginPageProps) {
+function LoginPage({ formComponent }: LoginPageProps) {
   return (
-      <Box w={"100vw"} h={"100vh"} bg={"white"}>
-        <Box as="header" bg={"brand.500"} p={6} zIndex="sticky" top={0}>
-          <Flex justify="end" align="center">
-            <HamburgerIcon as="button" w={8} h={8} color="white" aria-label="Open Menu" />
-          </Flex>
-        </Box>
-        <VStack bg={"background.900"} px={10} pt={20}>
-          <Flex w={"100%"} align={"center"} justify={"start"} mb={10}>
-            <ChevronLeftIcon as="button" w={8} h={8} color="brand.500" aria-label="Go Back" />
-            <Heading size={"sm"} m={"auto"}>
-              Login
-            </Heading>
-          </Flex>
-          {/* Below is where the Login Form will be rendered. */}
-          {formComponent}
-        </VStack>
+    <Box w={'100vw'} h={'100vh'} bg={'white'}>
+      <Box as="header" bg={'brand.500'} p={6} zIndex="sticky" top={0}>
+        <Flex justify="end" align="center">
+          <HamburgerIcon as="button" w={8} h={8} color="white" aria-label="Open Menu" />
+        </Flex>
       </Box>
+      <VStack bg={'background.900'} px={10} pt={20}>
+        <Flex w={'100%'} align={'center'} justify={'start'} mb={10}>
+          <ChevronLeftIcon as="button" w={8} h={8} color="brand.500" aria-label="Go Back" />
+          <Heading size={'sm'} m={'auto'}>
+              Login
+          </Heading>
+        </Flex>
+        {/* Below is where the Login Form will be rendered. */}
+        {formComponent}
+      </VStack>
+    </Box>
   );
 }
 

--- a/apps/frontend/src/components/LoginPage.tsx
+++ b/apps/frontend/src/components/LoginPage.tsx
@@ -8,11 +8,11 @@ import {
 import { HamburgerIcon, ChevronLeftIcon } from "@chakra-ui/icons";
 
 interface LoginPageProps {
-  children: React.ReactNode;
+  formComponent: React.ReactNode;
 }
 
 // Add Header component created by Toco following rebase / merge
-function LoginPage( { children }: LoginPageProps) {
+function LoginPage( { formComponent }: LoginPageProps) {
   return (
       <Box w={"100vw"} h={"100vh"} bg={"white"}>
         <Box as="header" bg={"brand.500"} p={6} zIndex="sticky" top={0}>
@@ -28,7 +28,7 @@ function LoginPage( { children }: LoginPageProps) {
             </Heading>
           </Flex>
           {/* Below is where the Login Form will be rendered. */}
-          {children}
+          {formComponent}
         </VStack>
       </Box>
   );

--- a/apps/frontend/src/components/NavigationButton.tsx
+++ b/apps/frontend/src/components/NavigationButton.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Button } from "@chakra-ui/react";
-import { useNavigate } from "react-router-dom";
+import React from 'react';
+import { Button } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 
 interface NavigationButtonProps {
     label: string;
@@ -8,17 +8,17 @@ interface NavigationButtonProps {
 }
 
 function NavigationButton({ to, label }: NavigationButtonProps) {
-    let navigate = useNavigate();
+  const navigate = useNavigate();
 
-    return (
-        <Button
-            colorScheme="brand"
-            w={"90%"}
-            onClick={ () => navigate(to) }
-        >
-            {label}
-        </Button>
-    )
+  return (
+    <Button
+      colorScheme="brand"
+      w={'90%'}
+      onClick={ () => navigate(to) }
+    >
+      {label}
+    </Button>
+  );
 }
 
 export default NavigationButton;

--- a/apps/frontend/src/components/PageLink.tsx
+++ b/apps/frontend/src/components/PageLink.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
-import { HStack, Link as ChakraLink } from '@chakra-ui/react';
+import { HStack, Link as ChakraLink, BoxProps } from '@chakra-ui/react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 
-interface PageLinkProps {
+interface PageLinkProps extends BoxProps {
     text: string;
     to: string;
-    padding?: number;
   }
 
-function PageLink({ text, to, padding } : PageLinkProps) {
+function PageLink({ text, to, ...rest } : PageLinkProps) {
   return (
-    <HStack w={'100%'} justify={'center'} p={padding} color={'#007bff'}>
+    <HStack w={'100%'} justify={'center'} color={'brand.500'} {...rest}>
       <ChakraLink as={ReactRouterLink} to={to}>
         <b>{text}</b>
       </ChakraLink>

--- a/apps/frontend/src/components/PageLink.tsx
+++ b/apps/frontend/src/components/PageLink.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { HStack,  Link as ChakraLink } from "@chakra-ui/react";
-import { Link as ReactRouterLink } from "react-router-dom";
+import React from 'react';
+import { HStack, Link as ChakraLink } from '@chakra-ui/react';
+import { Link as ReactRouterLink } from 'react-router-dom';
 
 interface PageLinkProps {
     text: string;
@@ -9,13 +9,13 @@ interface PageLinkProps {
   }
 
 function PageLink({ text, to, padding } : PageLinkProps) {
-    return (
-      <HStack w={"100%"} justify={"center"} p={padding} color={"#007bff"}>
-        <ChakraLink as={ReactRouterLink} to={to}>
-          <b>{text}</b>
-        </ChakraLink>
-      </HStack>
-    );
-  }
+  return (
+    <HStack w={'100%'} justify={'center'} p={padding} color={'#007bff'}>
+      <ChakraLink as={ReactRouterLink} to={to}>
+        <b>{text}</b>
+      </ChakraLink>
+    </HStack>
+  );
+}
 
 export default PageLink;

--- a/apps/frontend/src/components/PageLink.tsx
+++ b/apps/frontend/src/components/PageLink.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { HStack,  Link as ChakraLink } from "@chakra-ui/react";
+import { Link as ReactRouterLink } from "react-router-dom";
+
+interface PageLinkProps {
+    text: string;
+    to: string;
+    padding?: number;
+  }
+
+function PageLink({ text, to, padding } : PageLinkProps) {
+    return (
+      <HStack w={"100%"} justify={"center"} p={padding} color={"#007bff"}>
+        <ChakraLink as={ReactRouterLink} to={to}>
+          <b>{text}</b>
+        </ChakraLink>
+      </HStack>
+    );
+  }
+
+export default PageLink;

--- a/apps/frontend/src/components/RegistrationForm.tsx
+++ b/apps/frontend/src/components/RegistrationForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
+import PageLink from './PageLink';
 
 const validationSchema = Yup.object({
   firstName: Yup.string()
@@ -108,13 +109,15 @@ function RegistrationForm() {
             Forgot password?
           </Button>
         </HStack>
+        <PageLink text={'Already have an account? Log in!'} to={'/login'} />
         <Button
           type="submit"
           w={'100%'}
           colorScheme="brand"
           variant="solid"
           mt={8}
-          p={6}
+          p={0}
+          m={'3'}
           disabled={formik.isSubmitting}
         >
           SIGN UP

--- a/apps/frontend/src/components/RegistrationForm.tsx
+++ b/apps/frontend/src/components/RegistrationForm.tsx
@@ -109,19 +109,18 @@ function RegistrationForm() {
             Forgot password?
           </Button>
         </HStack>
-        <PageLink text={'Already have an account? Log in!'} to={'/login'} />
         <Button
           type="submit"
           w={'100%'}
           colorScheme="brand"
           variant="solid"
           mt={8}
-          p={0}
-          m={'3'}
+          m={5}
           disabled={formik.isSubmitting}
         >
           SIGN UP
         </Button>
+        <PageLink text={'Already have an account? Log in!'} to={'/login'} paddingBottom={20} />
       </VStack>
     </form>
   );

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -16,8 +16,8 @@ function LandingPage() {
         src="gcn_logo.svg"
         alt="gcn_logo"
       /> */}
-       <NavigationButton label='LOGIN' to='/login'  />
-       <NavigationButton label='SIGN UP' to='/register' />
+      <NavigationButton label="LOGIN" to="/login" />
+      <NavigationButton label="SIGN UP" to="/register" />
     </VStack>
   );
 }

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { VStack } from '@chakra-ui/react';
 
 import PageLayout from './PageLayout';
 import PageTitle from '../components/PageTitle';
+import PageLink from '../components/PageLink';
 
 interface LoginPageProps {
   formComponent: React.ReactNode;
@@ -20,6 +21,7 @@ function LoginPage({ formComponent }: LoginPageProps) {
         <PageTitle title={'Login'} />
         {formComponent}
       </VStack>
+      <PageLink text={"Don't have an account? Sign up!"} to={'/register'} padding={6} />
     </PageLayout>
   );
 }

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -20,7 +20,7 @@ function LoginPage({ formComponent }: LoginPageProps) {
       >
         <PageTitle title={'Login'} />
         {formComponent}
-        <PageLink text={"Don't have an account? Sign up!"} to={'/register'} />
+        <PageLink text={"Don't have an account? Sign up!"} to={'/register'} p={4} />
       </VStack>
     </PageLayout>
   );

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -20,8 +20,8 @@ function LoginPage({ formComponent }: LoginPageProps) {
       >
         <PageTitle title={'Login'} />
         {formComponent}
+        <PageLink text={"Don't have an account? Sign up!"} to={'/register'} />
       </VStack>
-      <PageLink text={"Don't have an account? Sign up!"} to={'/register'} padding={6} />
     </PageLayout>
   );
 }

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -1,15 +1,15 @@
-import React from "react";
-import {VStack} from "@chakra-ui/react";
+import React from 'react';
+import { VStack } from '@chakra-ui/react';
 
-import PageLayout from "./PageLayout";
-import PageTitle from "../components/PageTitle";
+import PageLayout from './PageLayout';
+import PageTitle from '../components/PageTitle';
 
 interface LoginPageProps {
   formComponent: React.ReactNode;
 }
 
 // Add Header component created by Toco following rebase / merge
-function LoginPage( { formComponent }: LoginPageProps) {
+function LoginPage({ formComponent }: LoginPageProps) {
   return (
     <PageLayout>
       <VStack


### PR DESCRIPTION
## Summary
- Added a link to `Login` page, called "Don't have an account? Sign up!", that goes to `Sign Up`
- Added a link to `Sign Up` page called, "Already have an account? Log in!", that goes to `Log In`

## Testing
1. Go to https://deploy-preview-86--geek-collectors-network.netlify.app/
4. Click on `Login` to navigate to the `Login` page
5. Click on `Don't have an account? Sign up!` and verify you navigate to the `Sign Up` page
6. Click on the `Already have an account? Sign in!` and verify you navigate to the `Login` page.