### PR TITLE
Enable api debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+    "configurations": [
+        {
+            "type": "bun",
+            "request": "attach",
+            "name": "Bun:debug",
+            "url": "ws://localhost:9229/gcn"
+        }
+    ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "start": "bun src/index.ts",
-    "start:dev": "bun --watch src/index.ts",
+    "start:dev": "bun --hot --inspect=0.0.0.0:9229/gcn src/index.ts",
     "lint": "eslint --ext ts src/ && tsc --noEmit -p tsconfig.json",
     "migrate": "drizzle-kit generate:mysql"
   }


### PR DESCRIPTION
### Summary
 - Add inspect flag to Bun in start:dev
 - Create debug launch profile

### Testing
1. Install Bun VSCode Extension: `oven.bun-vscode`
2. Spin-up the db: `make res`
3. Start the API server: `npm run -w apps/api start:dev`
4. In VSCode, set a breakpoint at `./src/server/server.ts:44`
5. Attach the debugger; Run the `Bun:debug` debug profile
6. Trigger a refresh
    - The application should be paused on the breakpoint
