### PR TITLE
Remove netlify components

### DIFF
--- a/apps/api/netlify.toml
+++ b/apps/api/netlify.toml
@@ -1,8 +1,0 @@
-[functions]
-  external_node_modules = ["express"]
-  node_bundler = "esbuild"
-[[redirects]]
-  force = true
-  from = "/*"
-  status = 200
-  to = "/.netlify/functions/api/:splat"

--- a/apps/api/netlify/functions/api.ts
+++ b/apps/api/netlify/functions/api.ts
@@ -1,6 +1,0 @@
-import serverless from 'serverless-http';
-import { Server } from '../../src/server/server';
-
-const { app } = new Server();
-
-export const handler = serverless(app);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,12 +16,10 @@
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
     "mysql2": "^3.9.1",
-    "serverless-http": "^3.2.0",
     "winston": "^3.11.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@netlify/functions": "^2.6.0",
     "@tsconfig/node18": "^18.2.1",
     "@types/express": "^4.17.21",
     "@types/express-mysql-session": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,12 +33,10 @@
         "helmet": "^7.1.0",
         "morgan": "^1.10.0",
         "mysql2": "^3.9.1",
-        "serverless-http": "^3.2.0",
         "winston": "^3.11.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@netlify/functions": "^2.6.0",
         "@tsconfig/node18": "^18.2.1",
         "@types/express": "^4.17.21",
         "@types/express-mysql-session": "^3.0.3",
@@ -2661,40 +2659,6 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
-    },
-    "node_modules/@netlify/functions": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.6.0.tgz",
-      "integrity": "sha512-vU20tij0fb4nRGACqb+5SQvKd50JYyTyEhQetCMHdakcJFzjLDivvRR16u1G2Oy4A7xNAtGJF1uz8reeOtTVcQ==",
-      "dev": true,
-      "dependencies": {
-        "@netlify/serverless-functions-api": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@netlify/node-cookies": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/node-cookies/-/node-cookies-0.1.0.tgz",
-      "integrity": "sha512-OAs1xG+FfLX0LoRASpqzVntVV/RpYkgpI0VrUnw2u0Q1qiZUzcPffxRK8HF3gc4GjuhG5ahOEMJ9bswBiZPq0g==",
-      "dev": true,
-      "engines": {
-        "node": "^14.16.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@netlify/serverless-functions-api": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.14.0.tgz",
-      "integrity": "sha512-HUNETLNvNiC2J+SB/YuRwJA9+agPrc0azSoWVk8H85GC+YE114hcS5JW+dstpKwVerp2xILE3vNWN7IMXP5Q5Q==",
-      "dev": true,
-      "dependencies": {
-        "@netlify/node-cookies": "^0.1.0",
-        "urlpattern-polyfill": "8.0.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10567,14 +10531,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/serverless-http": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
-      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/set-function-length": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
@@ -11792,12 +11748,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/urlpattern-polyfill": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
-      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
-      "dev": true
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.1",


### PR DESCRIPTION
### Summary
 - Remove Netlify dependencies and serverless components 

### Retrospective
Netlify has been a real struggle to get working properly with the API. While it works perfectly fine for hosting webpages/frontends, trying to host express APIs feels like a secondary concern and ultimately, incomplete.

I spent some time looking at free alternatives other than Vercel and Netlify and I came across Qovery and Render, of-which I took the latter.