### PR TITLE
Fix api response corruption

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,10 +1,14 @@
 {
     "configurations": [
         {
-            "type": "bun",
+            "type": "node",
+            "name": "Attach",
+            "port": 9229,
             "request": "attach",
-            "name": "Bun:debug",
-            "url": "ws://localhost:9229/gcn"
+            "restart": true,
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
         }
     ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "start": "tsx src/index.ts",
-    "start:dev": "tsx watch src/index.ts",
+    "start:dev": "tsx watch --inspect=0.0.0.0:9229 -r dotenv/config src/index.ts",
     "lint": "eslint --ext ts src/ && tsc --noEmit -p tsconfig.json",
     "migrate": "drizzle-kit generate:mysql"
   }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,14 +26,15 @@
     "@types/express-session": "^1.17.10",
     "@types/morgan": "^1.9.9",
     "@types/node": "^18.17.14",
-    "bun": "^1.0.29",
+    "dotenv": "^16.4.5",
     "drizzle-kit": "^0.20.14",
     "tsconfig-paths": "^4.2.0",
+    "tsx": "^4.7.1",
     "typescript": "^5.3.3"
   },
   "scripts": {
-    "start": "bun src/index.ts",
-    "start:dev": "bun --hot --inspect=0.0.0.0:9229/gcn src/index.ts",
+    "start": "tsx src/index.ts",
+    "start:dev": "tsx watch src/index.ts",
     "lint": "eslint --ext ts src/ && tsc --noEmit -p tsconfig.json",
     "migrate": "drizzle-kit generate:mysql"
   }

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -5,7 +5,6 @@ ARG WORKSPACE=/app
 ARG USER=node
 
 ARG DOCKER_NODE_VERSION=latest
-ARG DOCKER_BUN_VERSION=latest
 ARG DOCKER_UBUNTU_VERSION=latest
 
 # ========================== NODE STAGE ==========================
@@ -74,7 +73,7 @@ CMD ["npm", "run", "start:dev"]
 
 
 # ========================== PRODUCTION STAGE ==========================
-FROM oven/bun:${DOCKER_BUN_VERSION} AS production
+FROM node:${DOCKER_NODE_VERSION} AS production
 ARG NAME
 
 ARG WORKSPACE
@@ -98,4 +97,4 @@ COPY --from=base --chown=${USER}:${USER} ${WORKSPACE}/packages ${WORKSPACE}/pack
 
 WORKDIR ${WORKSPACE}/${NAME}
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["bun", "./src/index.ts"]
+CMD ["npx", "--no-install", "tsx", "./src/index.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,10 @@
         "@types/express-session": "^1.17.10",
         "@types/morgan": "^1.9.9",
         "@types/node": "^18.17.14",
-        "bun": "^1.0.29",
+        "dotenv": "^16.4.5",
         "drizzle-kit": "^0.20.14",
         "tsconfig-paths": "^4.2.0",
+        "tsx": "^4.7.1",
         "typescript": "^5.3.3"
       }
     },
@@ -2692,84 +2693,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@oven/bun-darwin-aarch64": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.0.29.tgz",
-      "integrity": "sha512-OhlPQO0zE7rgZ2LpkLr3A3cOoS6V+V3QvkPtlwB5TLlnrbcs78rnRBse/ibl46GAA1HnEn1ugxbsjAJkZ31WVA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oven/bun-darwin-x64": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.0.29.tgz",
-      "integrity": "sha512-y7zjOWdUl7rtzt900XTYPwaSL0qBZpkGmHJNqEMmhVuqUclMwmQmqUnBDMoKwgW84nLQXkzcKyBZlOBNohpQZw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oven/bun-darwin-x64-baseline": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.0.29.tgz",
-      "integrity": "sha512-/4RLSFIO+a0wVBR6/OZqEZJX3lGjPKK30V1Nce+ziceuk2Hmm+MsmzK/704UDi9MWWtXdRhe9Ayd4yZ+C0kZww==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oven/bun-linux-aarch64": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.0.29.tgz",
-      "integrity": "sha512-X8czxV2WBKSO4tctlmgImhYeWIuD4Abd2gvwUqwDliMsMhkNL/AiLcbgS3M7TCG+YFsqyIkOj2uf7nixs3hIPA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oven/bun-linux-x64": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.0.29.tgz",
-      "integrity": "sha512-i9YbwQ2sh+IiruNq3nhKvZx0piZkMf/b58jkxbjxW+WfgNFpo0EMuj+ZwNDjF9VC6SMbsI9CoC6lmP4+CCM3nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oven/bun-linux-x64-baseline": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.0.29.tgz",
-      "integrity": "sha512-mZTBwBi94dU9229M2z24euFIMHbeHbMrrlzl3f+CKPzZxKPe5FG6EOudr8xRCoiuvZGgbvbkqZeRFJQjpVdOfg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4146,33 +4069,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
-    "node_modules/bun": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/bun/-/bun-1.0.29.tgz",
-      "integrity": "sha512-OQfMWb+UxgBA5Fnne/6GPmk3kh9HmECOIGG2P/m97QYmCthKMJlFBF8Q5TC+ayL5TvfVEXZxw7V4yHr1cqGK6w==",
-      "cpu": [
-        "arm64",
-        "x64"
-      ],
-      "dev": true,
-      "hasInstallScript": true,
-      "os": [
-        "darwin",
-        "linux"
-      ],
-      "bin": {
-        "bun": "bin/bun",
-        "bunx": "bin/bun"
-      },
-      "optionalDependencies": {
-        "@oven/bun-darwin-aarch64": "1.0.29",
-        "@oven/bun-darwin-x64": "1.0.29",
-        "@oven/bun-darwin-x64-baseline": "1.0.29",
-        "@oven/bun-linux-aarch64": "1.0.29",
-        "@oven/bun-linux-x64": "1.0.29",
-        "@oven/bun-linux-x64-baseline": "1.0.29"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5037,6 +4933,18 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dreamopt": {
@@ -11528,6 +11436,25 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/tsx": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.1.tgz",
+      "integrity": "sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type": {
       "version": "1.2.0",


### PR DESCRIPTION
### Summary
Bun has a bug that caused the Date and Transfer-Encoding headers to be written after the response body. Strangely, it only happens when the requests include a express-sessions cookie.

The following changes were made:
 - Replace Bun with TSX
 - Use dotenv for reading .env in lieu of Node20 `--env-file=`

If the start-up is still not acceptable we can try the following optimizations:
 1. **Use Node20:** I've done benchmarking between Node18, Node20, and Bun -- Node20 has greater runtime performance when compared to Node18 but I'm unsure if the start-up time is any greater.
 2. **Enable NodeJS ESM:** Changes how NodeJS performs module resolution. It supposedly offers greater start-up performance by forcing developers to end all relative file imports with `.js` so the node module importer does not have to perform validation checks (I/O ops) to determine if the reference file is ACTUALLY a file or a folder. [Source](https://www.youtube.com/watch?v=8ORIzvgNWhU).

### Testing
1. Install new dependencies: `make install`
2. Spin up resources: `make res`
3. Start the api server: `npm run -w apps/api start:dev`
4. Use Postman (or Thunder Client) to create an account. `http://127.0.0.1:3000/api/v1/auth/signup`
5. Log in once, expect `{ userId: 4 }` or similar. `http://127.0.0.1:3000/api/v1/auth/login`
6. Log in again, expect the same result.
