### PR TITLE
feat(api): get friends list api endpoint

### DIFF
--- a/apps/api/drizzle/0001_daffy_thor.sql
+++ b/apps/api/drizzle/0001_daffy_thor.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `friendship` MODIFY COLUMN `text` varchar(200);--> statement-breakpoint
+ALTER TABLE `friendship` DROP INDEX `friendship_text_unique`;

--- a/apps/api/drizzle/meta/0001_snapshot.json
+++ b/apps/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,346 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f1afbb59-015d-47dc-a4dc-281df6fa17d0",
+  "prevId": "6a84ea98-c855-4c7b-9cea-a346ee74585b",
+  "tables": {
+    "friendship": {
+      "name": "friendship",
+      "columns": {
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','accepted','rejected','blocked')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "friendship_inviter_id_user_id_fk": {
+          "name": "friendship_inviter_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friendship_invitee_id_user_id_fk": {
+          "name": "friendship_invitee_id_user_id_fk",
+          "tableFrom": "friendship",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friendship_inviter_id_invitee_id_pk": {
+          "name": "friendship_inviter_id_invitee_id_pk",
+          "columns": [
+            "inviter_id",
+            "invitee_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tag_creator_id_user_id_fk": {
+          "name": "tag_creator_id_user_id_fk",
+          "tableFrom": "tag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tag_id": {
+          "name": "tag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tag_text_unique": {
+          "name": "tag_text_unique",
+          "columns": [
+            "text"
+          ]
+        }
+      }
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "about": {
+          "name": "about",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "user_to_tag": {
+      "name": "user_to_tag",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_to_tag_user_id_user_id_fk": {
+          "name": "user_to_tag_user_id_user_id_fk",
+          "tableFrom": "user_to_tag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_to_tag_tag_id_tag_id_fk": {
+          "name": "user_to_tag_tag_id_tag_id_fk",
+          "tableFrom": "user_to_tag",
+          "tableTo": "tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_to_tag_user_id_tag_id_pk": {
+          "name": "user_to_tag_user_id_tag_id_pk",
+          "columns": [
+            "user_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1710629043393,
       "tag": "0000_overrated_fabian_cortez",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1710898652585,
+      "tag": "0001_daffy_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/models/dummy.ts
+++ b/apps/api/src/models/dummy.ts
@@ -284,25 +284,30 @@ for (let userId = 1; userId <= DUMMY_USERS.length; userId++) {
 }
 
 const DUMMY_FRIENDSHIPS: FriendshipsType[] = [
-  // John Doe
+  // John Doe sends requests...
   { inviterId: 2, inviteeId: 3, message: 'Hey Alice, let\'s be friends!', status: 'pending' },
   { inviterId: 2, inviteeId: 4, message: 'Hey Jane, let\'s be friends!', status: 'pending' },
-  { inviterId: 2, inviteeId: 5, message: 'Hey William, let\'s be friends!', status: 'pending' },
 
+  { inviterId: 2, inviteeId: 5, message: 'Hey William, let\'s be friends!', status: 'accepted' },
   { inviterId: 2, inviteeId: 6, message: 'Hey Sherlock, let\'s be friends!', status: 'accepted' },
   { inviterId: 2, inviteeId: 7, message: 'Hey Bruce, let\'s be friends!', status: 'accepted' },
-  { inviterId: 2, inviteeId: 8, message: 'Hey Hermione, let\'s be friends!', status: 'accepted' },
 
-  { inviterId: 2, inviteeId: 9, message: 'Hey Peter, let\'s be friends!', status: 'rejected' },
-  { inviterId: 2, inviteeId: 10, message: 'Hey Tony, let\'s be friends!', status: 'rejected' },
+  { inviterId: 2, inviteeId: 8, message: 'Hey Hermione, let\'s be friends!', status: 'rejected' },
 
-  { inviterId: 2, inviteeId: 11, message: 'Hey Clark, let\'s be friends!', status: 'blocked' },
-  { inviterId: 2, inviteeId: 12, message: 'Hey Bruce, let\'s be friends!', status: 'blocked' },
+  { inviterId: 2, inviteeId: 9, message: 'Hey Peter, let\'s be friends!', status: 'blocked' },
 
-  { inviterId: 13, inviteeId: 2, message: 'Hey John, it\'s Diana, let\'s be friends!', status: 'pending' },
-  { inviterId: 14, inviteeId: 2, message: 'Hey John, it\'s Thor, let\'s be friends!', status: 'pending' },
-  { inviterId: 15, inviteeId: 2, message: 'Hey John, it\'s Hulk, let\'s be friends!', status: 'pending' },
+  // John Doe recieves requests...
+  { inviterId: 10, inviteeId: 2, message: 'Hey John, it\'s Tony, let\'s be friends!', status: 'pending' },
+  { inviterId: 11, inviteeId: 2, message: 'Hey John, it\'s Clark, let\'s be friends!', status: 'pending' },
 
+  { inviterId: 12, inviteeId: 2, message: 'Hey John, it\'s Bruce, let\'s be friends!', status: 'accepted' },
+  { inviterId: 13, inviteeId: 2, message: 'Hey John, it\'s Diana, let\'s be friends!', status: 'accepted' },
+
+  { inviterId: 14, inviteeId: 2, message: 'Hey John, it\'s Thor, let\'s be friends!', status: 'rejected' },
+
+  { inviterId: 15, inviteeId: 2, message: 'Hey John, it\'s Hulk, let\'s be friends!', status: 'blocked' },
+
+  // John Doe has 5 current friends total
 ];
 
 export const writeDummyToDb = async (db: ReturnType<typeof drizzle>) => {

--- a/apps/api/src/models/dummy.ts
+++ b/apps/api/src/models/dummy.ts
@@ -293,7 +293,6 @@ const DUMMY_FRIENDSHIPS: FriendshipsType[] = [
   { inviterId: 2, inviteeId: 7, message: 'Hey Bruce, let\'s be friends!', status: 'accepted' },
 
   { inviterId: 2, inviteeId: 8, message: 'Hey Hermione, let\'s be friends!', status: 'rejected' },
-
   { inviterId: 2, inviteeId: 9, message: 'Hey Peter, let\'s be friends!', status: 'blocked' },
 
   // John Doe recieves requests...
@@ -304,10 +303,20 @@ const DUMMY_FRIENDSHIPS: FriendshipsType[] = [
   { inviterId: 13, inviteeId: 2, message: 'Hey John, it\'s Diana, let\'s be friends!', status: 'accepted' },
 
   { inviterId: 14, inviteeId: 2, message: 'Hey John, it\'s Thor, let\'s be friends!', status: 'rejected' },
-
   { inviterId: 15, inviteeId: 2, message: 'Hey John, it\'s Hulk, let\'s be friends!', status: 'blocked' },
 
   // John Doe has 5 current friends total
+
+  // 2 mutual friends with Alice (NOT current friends with John)
+  { inviterId: 3, inviteeId: 4, message: '', status: 'accepted' },
+  { inviterId: 3, inviteeId: 5, message: '', status: 'accepted' },
+  { inviterId: 3, inviteeId: 6, message: '', status: 'accepted' },
+
+  // 3 mutual friends with William (IS current friends with John)
+  { inviterId: 5, inviteeId: 6, message: '', status: 'accepted' },
+  { inviterId: 5, inviteeId: 7, message: '', status: 'accepted' },
+  { inviterId: 5, inviteeId: 12, message: '', status: 'accepted' },
+
 ];
 
 export const writeDummyToDb = async (db: ReturnType<typeof drizzle>) => {

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -41,7 +41,7 @@ export const friendships = mysqlTable('friendship', {
   status: mysqlEnum('status', ['pending', 'accepted', 'rejected', 'blocked']).notNull().default('pending'),
 }, table => ({
   pk: primaryKey({ columns: [table.inviterId, table.inviteeId] }),
-
+  // TODO: prevent duplicate rows with inviterId and inviteeId swapped
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -37,7 +37,7 @@ export const usersToTags = mysqlTable('user_to_tag', {
 export const friendships = mysqlTable('friendship', {
   inviterId: int('inviter_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   inviteeId: int('invitee_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  message: varchar('text', { length: 200 }).notNull().unique(),
+  message: varchar('text', { length: 200 }),
   status: mysqlEnum('status', ['pending', 'accepted', 'rejected', 'blocked']).notNull().default('pending'),
 }, table => ({
   pk: primaryKey({ columns: [table.inviterId, table.inviteeId] }),

--- a/apps/api/src/server/routes/v1.ts
+++ b/apps/api/src/server/routes/v1.ts
@@ -26,6 +26,8 @@ export class Routes {
     router.get('/user/:userId?/profile', authenticate, use((req, res) => this.userService.handleGetProfile(req, res)));
     router.patch('/user/profile', authenticate, use((req, res) => this.userService.handleEditProfile(req, res)));
 
+    router.get('/user/friends', authenticate, use((req, res) => this.userService.handleGetFriendslist(req, res)));
+
     return router;
   }
 }

--- a/apps/api/src/server/services/UserService.ts
+++ b/apps/api/src/server/services/UserService.ts
@@ -65,8 +65,11 @@ export class UserController {
     const friendProfiles = await this.resources.db
       .select({
         id: users.id,
+        firstName: users.firstName,
+        lastName: users.lastName,
         displayName: users.displayName,
         profileImageUrl: users.profileImageUrl,
+        email: users.email,
         twitter: users.twitter,
         facebook: users.facebook,
         instagram: users.instagram,

--- a/apps/api/src/server/services/UserService.ts
+++ b/apps/api/src/server/services/UserService.ts
@@ -67,9 +67,8 @@ export class UserController {
     return friendshipIds.map(friend => (friend.inviterId === id ? friend.inviteeId : friend.inviterId));
   }
 
-  public async getFriendslist(id: number) {
-    const friendIds = await this.getFriendshipIds(id);
-    const friendProfiles = await this.resources.db
+  public async getFriendProfiles(friendIds: number[]) {
+    return await this.resources.db
       .select({
         id: users.id,
         firstName: users.firstName,
@@ -83,8 +82,13 @@ export class UserController {
       })
       .from(users)
       .where(inArray(users.id, friendIds)) as FriendProfile[];
+  }
 
+  public async getFriendslist(id: number) {
+    const friendIds = await this.getFriendshipIds(id);
+    const friendProfiles = await this.getFriendProfiles(friendIds);
     const friendsOfFriends = await Promise.all(friendProfiles.map(friend => this.getFriendshipIds(friend.id!)));
+
     friendProfiles.forEach((friend, index) => {
       const mutualFriendsCount = friendsOfFriends[index].filter(friendId => friendIds.includes(friendId)).length;
       friend.mutualFriends = mutualFriendsCount;


### PR DESCRIPTION
### Summary
Add endpoint to get a user's friends.

GET `/api/v1/user/friends` return with something like
```json
"data": [
        {
            "id": 5,
            "displayName": "The Bard",
            "profileImageUrl": "https://robohash.org/TheBard",
            "twitter": null,
            "facebook": null,
            "instagram": "william.shakespeare"
        }
]
```

Make dummy data better for testing (all combos of states, invitee/inviter).

There's ~~probably~~ definitely a more efficient way of getting the user data, but I can't figure out how to do it with drizzle and I think this will suffice for now.

### Testing
Login as john.doe@email.com and hit up the route to see his 5 friends. Verify against db.
