### PR TITLE
feat(db): add item models to schema

### DIFF
--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -51,7 +51,7 @@ export const items = mysqlTable('item', {
   createdAt: timestamp('created_at').notNull().$defaultFn(() => new Date()),
   updatedAt: timestamp('updated_at').onUpdateNow(),
   creatorId: int('creator_id').references(() => users.id, { onDelete: 'set null' }),
-  description: varchar('text', { length: 1000 }).notNull().unique(),
+  description: varchar('text', { length: 1000 }),
   imageUrl: varchar('image_url', { length: 255 }),
   brand: varchar('brand', { length: 50 }),
   price: int('price').notNull(), // in cents

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, date, int, mysqlEnum, mysqlTable, primaryKey, timestamp, varchar } from 'drizzle-orm/mysql-core';
+import { boolean, date, decimal, int, mysqlEnum, mysqlTable, primaryKey, text, timestamp, varchar } from 'drizzle-orm/mysql-core';
 import { InferInsertModel, relations } from 'drizzle-orm';
 
 /*        ENTITY DEFINITIONS        */
@@ -51,11 +51,11 @@ export const items = mysqlTable('item', {
   createdAt: timestamp('created_at').notNull().$defaultFn(() => new Date()),
   updatedAt: timestamp('updated_at').onUpdateNow(),
   creatorId: int('creator_id').references(() => users.id, { onDelete: 'set null' }),
-  title: varchar('title', { length: 50 }).notNull(),
-  description: varchar('text', { length: 1000 }),
+  name: varchar('name', { length: 50 }).notNull(),
+  description: text('description'),
   imageUrl: varchar('image_url', { length: 255 }),
   brand: varchar('brand', { length: 50 }),
-  price: int('price').notNull(), // in cents
+  price: decimal('price', { precision: 2 }),
   isForSale: boolean('is_for_sale').notNull().default(false),
   isForTrade: boolean('is_for_trade').notNull().default(false),
   soldAt: timestamp('sold_at'),

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -1,5 +1,7 @@
-import { date, int, mysqlEnum, mysqlTable, primaryKey, timestamp, varchar } from 'drizzle-orm/mysql-core';
+import { boolean, date, int, mysqlEnum, mysqlTable, primaryKey, timestamp, varchar } from 'drizzle-orm/mysql-core';
 import { InferInsertModel, relations } from 'drizzle-orm';
+
+/*        ENTITY DEFINITIONS        */
 
 export const users = mysqlTable('user', {
   id: int('id').primaryKey().autoincrement(),
@@ -44,6 +46,23 @@ export const friendships = mysqlTable('friendship', {
   // TODO: prevent duplicate rows with inviterId and inviteeId swapped
 }));
 
+export const items = mysqlTable('item', {
+  id: int('id').primaryKey().autoincrement(),
+  createdAt: timestamp('created_at').notNull().$defaultFn(() => new Date()),
+  updatedAt: timestamp('updated_at').onUpdateNow(),
+  creatorId: int('creator_id').references(() => users.id, { onDelete: 'set null' }),
+  description: varchar('text', { length: 1000 }).notNull().unique(),
+  imageUrl: varchar('image_url', { length: 255 }),
+  brand: varchar('brand', { length: 50 }),
+  price: int('price').notNull(), // in cents
+  isForSale: boolean('is_for_sale').notNull().default(false),
+  isForTrade: boolean('is_for_trade').notNull().default(false),
+  soldAt: timestamp('sold_at'),
+});
+
+
+/*        ENTITY RELATIONS        */
+
 export const usersRelations = relations(users, ({ many }) => ({
   tags: many(usersToTags),
 }));
@@ -67,8 +86,10 @@ export const usersToTagsRelations = relations(usersToTags, ({ one }) => ({
   }),
 }));
 
+/*        ENTITY TYPES        */
 
 export type UsersType = InferInsertModel<typeof users>;
 export type TagsType = InferInsertModel<typeof tags>;
 export type UsersToTagsType = InferInsertModel<typeof usersToTags>;
 export type FriendshipsType = InferInsertModel<typeof friendships>;
+export type ItemsType = InferInsertModel<typeof items>;

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -51,6 +51,7 @@ export const items = mysqlTable('item', {
   createdAt: timestamp('created_at').notNull().$defaultFn(() => new Date()),
   updatedAt: timestamp('updated_at').onUpdateNow(),
   creatorId: int('creator_id').references(() => users.id, { onDelete: 'set null' }),
+  title: varchar('title', { length: 50 }).notNull(),
   description: varchar('text', { length: 1000 }),
   imageUrl: varchar('image_url', { length: 255 }),
   brand: varchar('brand', { length: 50 }),

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -101,6 +101,40 @@ export const usersToTagsRelations = relations(usersToTags, ({ one }) => ({
   }),
 }));
 
+export const itemsRelations = relations(items, ({ one, many }) => ({
+  creator: one(users, {
+    fields: [items.creatorId],
+    references: [users.id],
+  }),
+  collection: one(itemsToUsersCollections, {
+    fields: [items.id],
+    references: [itemsToUsersCollections.itemId],
+  }),
+  wishlists: many(itemsToUsersWishlists),
+}));
+
+export const itemsToUsersCollectionsRelations = relations(itemsToUsersCollections, ({ one }) => ({
+  item: one(items, {
+    fields: [itemsToUsersCollections.itemId],
+    references: [items.id],
+  }),
+  user: one(users, {
+    fields: [itemsToUsersCollections.userId],
+    references: [users.id],
+  }),
+}));
+
+export const itemsToUsersWishlistsRelations = relations(itemsToUsersWishlists, ({ one }) => ({
+  item: one(items, {
+    fields: [itemsToUsersWishlists.itemId],
+    references: [items.id],
+  }),
+  user: one(users, {
+    fields: [itemsToUsersWishlists.userId],
+    references: [users.id],
+  }),
+}));
+
 /*        ENTITY TYPES        */
 
 export type UsersType = InferInsertModel<typeof users>;

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -76,6 +76,13 @@ export const itemsToUsersWishlists = mysqlTable('item_to_user_wishlist', {
   pk: primaryKey({ columns: [table.itemId, table.userId] }),
 }));
 
+export const itemsToTags = mysqlTable('user_to_tag', {
+  itemId: int('user_id').notNull().references(() => items.id, { onDelete: 'cascade' }),
+  tagId: int('tag_id').notNull().references(() => tags.id, { onDelete: 'cascade' }),
+}, table => ({
+  pk: primaryKey({ columns: [table.itemId, table.tagId] }),
+}));
+
 /*        ENTITY RELATIONS        */
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -111,6 +118,7 @@ export const itemsRelations = relations(items, ({ one, many }) => ({
     references: [itemsToUsersCollections.itemId],
   }),
   wishlists: many(itemsToUsersWishlists),
+  tags: many(itemsToTags),
 }));
 
 export const itemsToUsersCollectionsRelations = relations(itemsToUsersCollections, ({ one }) => ({
@@ -135,6 +143,17 @@ export const itemsToUsersWishlistsRelations = relations(itemsToUsersWishlists, (
   }),
 }));
 
+export const itemsToTagsRelations = relations(itemsToTags, ({ one }) => ({
+  item: one(items, {
+    fields: [itemsToTags.itemId],
+    references: [items.id],
+  }),
+  tag: one(tags, {
+    fields: [itemsToTags.tagId],
+    references: [tags.id],
+  }),
+}));
+
 /*        ENTITY TYPES        */
 
 export type UsersType = InferInsertModel<typeof users>;
@@ -144,3 +163,4 @@ export type FriendshipsType = InferInsertModel<typeof friendships>;
 export type ItemsType = InferInsertModel<typeof items>;
 export type ItemsToUsersCollectionsType = InferInsertModel<typeof itemsToUsersCollections>;
 export type ItemsToUsersWishlistsType = InferInsertModel<typeof itemsToUsersWishlists>;
+export type ItemsToTagsType = InferInsertModel<typeof itemsToTags>;

--- a/apps/api/src/models/schema.ts
+++ b/apps/api/src/models/schema.ts
@@ -60,6 +60,21 @@ export const items = mysqlTable('item', {
   soldAt: timestamp('sold_at'),
 });
 
+export const itemsToUsersCollections = mysqlTable('item_to_user_collection', {
+  itemId: int('item_id').unique().notNull().references(() => items.id, { onDelete: 'cascade' }),
+  userId: int('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  isPublic: boolean('is_visible').notNull().default(true),
+}, table => ({
+  pk: primaryKey({ columns: [table.itemId, table.userId] }),
+}));
+
+export const itemsToUsersWishlists = mysqlTable('item_to_user_wishlist', {
+  itemId: int('item_id').notNull().references(() => items.id, { onDelete: 'cascade' }),
+  userId: int('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  isPublic: boolean('is_visible').notNull().default(true),
+}, table => ({
+  pk: primaryKey({ columns: [table.itemId, table.userId] }),
+}));
 
 /*        ENTITY RELATIONS        */
 
@@ -93,3 +108,5 @@ export type TagsType = InferInsertModel<typeof tags>;
 export type UsersToTagsType = InferInsertModel<typeof usersToTags>;
 export type FriendshipsType = InferInsertModel<typeof friendships>;
 export type ItemsType = InferInsertModel<typeof items>;
+export type ItemsToUsersCollectionsType = InferInsertModel<typeof itemsToUsersCollections>;
+export type ItemsToUsersWishlistsType = InferInsertModel<typeof itemsToUsersWishlists>;


### PR DESCRIPTION
### Summary
Add preliminary item models (and their relations) to schema.

- `item`
- `itemsToUsersCollections` item is in user's collection)
- `itemsToUsersWishlists` item is in user's wishlist)
- `itemsToTags` assoc. tags with an item

