### PR TITLE
feat(frontend): add interests section

### DIFF
--- a/apps/frontend/src/components/TagInput.tsx
+++ b/apps/frontend/src/components/TagInput.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import { Flex, Box, Tag, TagCloseButton, Input } from '@chakra-ui/react';
+
+type TagInputProps = {
+  tags: string[];
+  setTags: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+function TagInput({ tags, setTags }: TagInputProps) {
+  const [tagInput, setTagInput] = useState('');
+
+  function addTag() {
+    const trimmedInput = tagInput.trim();
+    if (trimmedInput.length > 0 && !tags.includes(trimmedInput)) {
+      setTags([...tags, tagInput]);
+      setTagInput('');
+    }
+  }
+
+  function removeTag(tag: string) {
+    setTags(tags.filter(t => t !== tag));
+  }
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Enter') {
+        addTag();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [tagInput, tags]);
+
+  return (
+    <Flex >
+      <Box w={'100%'}>
+        <Input
+          value={tagInput}
+          onChange={e => setTagInput(e.target.value)}
+          border={'none'}
+          focusBorderColor={'transparent'}
+          placeholder="Add interests..."
+          w={'100%'}
+          mb={2}
+        />
+        {tags.map(tag => (
+          <Tag key={tag} size="lg" m={1} backgroundColor={'brand.100'} borderRadius={'15px'}>
+            {tag}
+            <TagCloseButton onClick={() => removeTag(tag)} />
+          </Tag>
+        ))}
+      </Box>
+    </Flex>
+  );
+}
+
+export default TagInput;

--- a/apps/frontend/src/pages/ProfileInfo.tsx
+++ b/apps/frontend/src/pages/ProfileInfo.tsx
@@ -4,6 +4,7 @@ import { Formik, Form, Field } from 'formik';
 import { profileSchema } from '../schemas/schemas';
 import PageLayout from '../components/PageLayout';
 import PageTitle from '../components/PageTitle';
+import TagInput from '../components/TagInput';
 
 const cities = ['Vancouver', 'Burnaby', 'Richmond', 'Surrey', 'Coquitlam', 'Langley', 'Abbotsford', 'Chilliwack', 'Kelowna'];
 
@@ -13,7 +14,6 @@ type ProfileInfo = {
   city: string;
   about: string;
 }
-
 
 function formatDate(date: Date) {
   const month = date.getUTCMonth() + 1; // Months are zero-indexed, so add 1
@@ -28,6 +28,7 @@ function formatDate(date: Date) {
 
 function ProfileInfo() {
   const [initialValues, setInitialValues] = useState<ProfileInfo | null>(null);
+  const [tags, setTags] = useState<string[]>(['Interest', 'Another Interest', 'One More Interest', 'Last Interest']);
 
   useEffect(() => {
     fetch('/api/v1/user/profile', {
@@ -66,7 +67,7 @@ function ProfileInfo() {
         bg={'background'}
         spacing={2}
         px={10}
-        pt={20}
+        py={20}
       >
         <PageTitle title={'Edit Profile'} />
         <Formik
@@ -102,8 +103,18 @@ function ProfileInfo() {
                 </FormControl>
                 <FormControl id={'about'} isInvalid={!!(formik.errors.about && formik.touched.about)}>
                   <FormLabel color={'gray.500'}>About:</FormLabel>
-                  <Field as={Textarea} name={'about'} border={'none'} focusBorderColor={'transparent'}></Field>
+                  <Field
+                    as={Textarea}
+                    name={'about'}
+                    border={'none'}
+                    focusBorderColor={'transparent'}
+                    resize={'none'}
+                    placeholder="Tell us about yourself..."/>
                   <FormErrorMessage>{formik.errors.about}</FormErrorMessage>
+                </FormControl>
+                <FormControl>
+                  <FormLabel color={'gray.500'}>Interests:</FormLabel>
+                  <TagInput tags={tags} setTags={setTags} />
                 </FormControl>
                 <Button
                   type="submit"


### PR DESCRIPTION
### Summary
Enhance the profile edit page by introducing a new section for interests. Users can input their interests and create new tags as needed.

### Testing

To verify functionality:

1. Login or sign up to access the `/dashboard` page.
2. Navigate to the `/profile/edit` page.
3. Add and remove tags in the newly added interests section.