### PR TITLE
Re-enable webpack-dev-server with api proxy

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -31,6 +31,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "scripts": {
+    "start:dev": "webpack-dev-server",
     "build": "webpack",
     "lint": "eslint --ext ts,tsx src/ && tsc --noEmit -p tsconfig.json"
   },

--- a/apps/frontend/webpack.config.js
+++ b/apps/frontend/webpack.config.js
@@ -25,6 +25,9 @@ module.exports = {
     hot: true,
     port: process.env.PORT,
     historyApiFallback: true,
+    proxy: {
+      '/api/v1': 'http://localhost:3000/',
+    },
   },
   module: {
     rules: [
@@ -47,4 +50,4 @@ module.exports = {
     //   patterns: [{ from: PUBLIC_PATH, to: DIST_PATH }],
     // }),
   ],
-}
+};


### PR DESCRIPTION
### Summary
 - Re-enabled  webpack-dev-server with API proxy
 - Re-added `npm run -w apps/frontend start:dev`

### Testing
1. Spin up resources: `make res`
1. Run both apps:
    - In one terminal, run `npm run -w apps/frontend start:dev`
    - In another terminal, run `npm run -w apps/api start:dev`
    - Sorry, there's not an easier way to launch two applications that use `--watch`
3. Navigate to the landing page: http://localhost:8080/
4. Make any text changes to `LandingPage.tsx` and observe hot reloading.
5. Login with any account: http://localhost:8080/login
    - User: `admin@email.com`
    - Password: `admin`
6. Check the profile section and verify you see profile details (for example DoB): http://localhost:8080/profile/edit
