### PR TITLE
Add user facing feedback to login page

### DIFF
--- a/apps/frontend/src/components/LoginForm.tsx
+++ b/apps/frontend/src/components/LoginForm.tsx
@@ -1,39 +1,75 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Form, Formik } from 'formik';
-import { Button, VStack } from '@chakra-ui/react';
+import { Button, VStack, useToast } from '@chakra-ui/react';
 
 import TextInput from './TextInput';
 import PageLink from './PageLink';
 import { loginSchema } from '../schemas/schemas';
 import LoginControls from './LoginControls';
 
-function login(navigate: (path: string) => void, values: Record<string, string>) {
-  fetch('/api/v1/auth/login', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(values),
-  })
-    .then(response => response.json())
-    .then(response => {
-      const { data, isError } = response;
+type LoginValues = {
+  email: string;
+  password: string;
+};
 
-      if (isError) return console.error(data);
-
-      return navigate('/dashboard');
+async function login(values: LoginValues): Promise<boolean> {
+  try {
+    const response = await fetch('/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
     });
+
+    if (!response.ok) {
+      throw new Error('Error with Network Request');
+    }
+
+    const data = await response.json();
+    if (data.isError) {
+      console.error(data.data);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.log('Login failed: ', error);
+    return false;
+  }
 }
 
 function LoginForm() {
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const toast = useToast();
+
+  const handleSubmit = async (values : LoginValues) => {
+    setIsLoading(true);
+    const success = await login(values);
+
+    if (success) {
+      toast({
+        title: 'Login Successful',
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      });
+      navigate('/dashboard');
+    } else {
+      toast({
+        title: 'Login Failed',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+    setIsLoading(false);
+  };
 
   return (
     <Formik
       initialValues={{ email: '', password: '' }}
       validationSchema={loginSchema}
-      onSubmit={login.bind(null, navigate)}
+      onSubmit={handleSubmit}
     >
       {formik => (
         <Form>
@@ -44,6 +80,7 @@ function LoginForm() {
             <LoginControls />
 
             <Button
+              isLoading={isLoading}
               type="submit"
               w={'100%'}
               colorScheme="brand"

--- a/apps/frontend/src/components/NavigationButton.tsx
+++ b/apps/frontend/src/components/NavigationButton.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 
-interface NavigationButtonProps {
+type NavigationButtonProps = {
     label: string;
     to: string;
     variant?: string;
@@ -10,13 +10,20 @@ interface NavigationButtonProps {
 
 function NavigationButton({ to, label, variant }: NavigationButtonProps) {
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleClick = () => {
+    setIsLoading(true);
+    navigate(to);
+  };
 
   return (
     <Button
+      isLoading={isLoading}
       colorScheme="brand"
       w={{ 'base': '90%', 'md': '50%', 'lg': '30%' }}
       variant={variant || 'solid'}
-      onClick={ () => navigate(to) }
+      onClick={ handleClick }
     >
       {label}
     </Button>

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, VStack } from '@chakra-ui/react';
+import { VStack } from '@chakra-ui/react';
 import NavigationButton from '../components/NavigationButton';
 
 function LandingPage() {


### PR DESCRIPTION
### Summary
- Added loading state to login button
- Added pop-up to show user if login was successful or not

This could be refactored to be more flexible and reusable. However, since we're in a time-crunch, I'm focused more on the functionality; if there's time, then we can refactor.

### Testing
- Spin up resources
- Navigate to `http://localhost:8080/login`
- Use a random login for login fail; check that failure notification pops up
- Use email: `jane.doe@email.com`, password: `password` for successful log in. Check that (1) The `Log In` button has a spinner, (2) that a green pop-up at the bottom of the page appears, (3) that you're routed to the dashboard page
