### PR TITLE
Add toast to profile account pages

### DIFF
--- a/apps/frontend/src/pages/account/AccountInfo.tsx
+++ b/apps/frontend/src/pages/account/AccountInfo.tsx
@@ -1,43 +1,71 @@
 import React, { useEffect, useState } from 'react';
-import { VStack, StackDivider, Button, FormControl, FormLabel, FormErrorMessage, Input } from '@chakra-ui/react';
+import { VStack, StackDivider, Button, FormControl, FormLabel, FormErrorMessage, Input, useToast } from '@chakra-ui/react';
 import { Formik, Form, Field } from 'formik';
-import { registrationSchema } from '../../schemas/schemas';
+import { updateProfileSchema } from '../../schemas/schemas';
 import PageLayout from '../../components/PageLayout';
 import loadingAnimation from '../../components/widgets/LoadingAnimation';
 
-type AccountInfo = {
+type AccountInfoProps = {
   firstName: string;
   lastName: string;
   email: string;
   password: string;
 }
 
-function editProfile(values: Record<string, string>) {
-  fetch('/api/v1/user/profile', {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      firstName: values.firstName,
-      lastName: values.lastName,
-      email: values.email,
-      password: values.password,
-    }),
-  })
-    .then(response => response.json())
-    .then(console.log);
+async function editProfile(values: Record<string, string>): Promise<boolean> {
+  try {
+    const response = await fetch('/api/v1/user/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
+        password: values.password,
+      }),
+    });
+
+    const data = await response.json();
+    if (!response.ok || data.isError) {
+      throw new Error(data.message || 'Failed to update profile due to network request error.');
+    }
+    return true;
+  } catch (error) {
+    console.log('Profile update failed: ', error);
+    return false;
+  }
 }
 
 function AccountInfo() {
-  const [initialValues, setInitialValues] = useState<AccountInfo | null>(null);
+  const [initialValues, setInitialValues] = useState<AccountInfoProps | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const toast = useToast();
 
+  const handleEditProfile = async (values: AccountInfoProps) => {
+    setIsLoading(true);
+    const success = await editProfile(values);
+    setIsLoading(false);
+
+    if (success) {
+      toast({
+        title: 'Profile succesfully updated!',
+        status: 'success',
+        duration: 2000,
+      });
+    } else {
+      toast({
+        title: 'Profile update failed.',
+        status: 'error',
+        duration: 3000,
+      });
+    }
+  };
+
+  // When component mounts, immediately fetch user data for display
   useEffect(() => {
     fetch('/api/v1/user/profile', {
       method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
     })
       .then(response => response.json())
       .then(({ data }) => setInitialValues(data))
@@ -57,34 +85,30 @@ function AccountInfo() {
 
       <Formik
         initialValues={initialValues}
-        validationSchema={registrationSchema}
-        onSubmit={editProfile}
+        validationSchema={updateProfileSchema}
+        onSubmit={handleEditProfile}
       >
         {formik => (
           <Form className="account-form">
             <VStack gap={1} divider={<StackDivider/>} >
               <FormControl id={'firstName'} isInvalid={!!(formik.errors.firstName && formik.touched.firstName)}>
                 <FormLabel>First Name</FormLabel>
-                <Field as={Input} name={'firstName'} isInvalid={false}></Field>
+                <Field as={Input} name={'firstName'}></Field>
                 <FormErrorMessage>{formik.errors.firstName}</FormErrorMessage>
               </FormControl>
               <FormControl id={'lastName'} isInvalid={!!(formik.errors.lastName && formik.touched.lastName)}>
                 <FormLabel>Last Name</FormLabel>
-                <Field as={Input} name={'lastName'} isInvalid={false} ></Field>
+                <Field as={Input} name={'lastName'}></Field>
                 <FormErrorMessage>{formik.errors.lastName}</FormErrorMessage>
               </FormControl>
               <FormControl id={'email'} isInvalid={!!(formik.errors.email && formik.touched.email)}>
                 <FormLabel>Email</FormLabel>
-                <Field as={Input} name={'email'} isInvalid={false} ></Field>
+                <Field as={Input} name={'email'}></Field>
                 <FormErrorMessage>{formik.errors.email}</FormErrorMessage>
-              </FormControl>
-              <FormControl id={'password'} isInvalid={!!(formik.errors.password && formik.touched.password)}>
-                <FormLabel>Password</FormLabel>
-                <Field as={Input} name={'password'} isInvalid={false} ></Field>
-                <FormErrorMessage>{formik.errors.password}</FormErrorMessage>
               </FormControl>
               <Button
                 className="submit-button"
+                isLoading={isLoading}
                 type="submit"
                 colorScheme="brand"
                 variant="outline"
@@ -93,8 +117,9 @@ function AccountInfo() {
                   border: '1px solid transparent',
                   color: 'white',
                 }}
-                disabled={!formik.dirty || formik.isSubmitting}>
-                                SAVE
+                disabled={!formik.dirty || formik.isSubmitting}
+              >
+                Update Profile
               </Button>
             </VStack>
           </Form>

--- a/apps/frontend/src/pages/account/AccountInfo.tsx
+++ b/apps/frontend/src/pages/account/AccountInfo.tsx
@@ -25,6 +25,7 @@ async function editProfile(values: Record<string, string>): Promise<boolean> {
       }),
     });
 
+
     const data = await response.json();
     if (!response.ok || data.isError) {
       throw new Error(data.message || 'Failed to update profile due to network request error.');
@@ -48,7 +49,7 @@ function AccountInfo() {
 
     if (success) {
       toast({
-        title: 'Profile succesfully updated!',
+        title: 'Profile successfully updated!',
         status: 'success',
         duration: 2000,
       });

--- a/apps/frontend/src/pages/account/AccountInfo.tsx
+++ b/apps/frontend/src/pages/account/AccountInfo.tsx
@@ -119,7 +119,7 @@ function AccountInfo() {
                 }}
                 disabled={!formik.dirty || formik.isSubmitting}
               >
-                Update Profile
+                SAVE
               </Button>
             </VStack>
           </Form>

--- a/apps/frontend/src/pages/profile/ProfileInfo.tsx
+++ b/apps/frontend/src/pages/profile/ProfileInfo.tsx
@@ -1,22 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import {
-  VStack,
-  StackDivider,
-  Avatar,
-  Button,
-  FormControl,
-  FormLabel,
-  FormErrorMessage,
-  Input,
-  Textarea,
+  VStack, StackDivider, Avatar, Button, FormControl, FormLabel,
+  FormErrorMessage, Input, Textarea, useToast, Box,
 } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 import { Formik, Form, Field } from 'formik';
 import { profileSchema } from '../../schemas/schemas';
 import PageLayout from '../../components/PageLayout';
 import { TagInfo, TagInput } from './TagInput';
 import loadingAnimation from '../../components/widgets/LoadingAnimation';
 
-type ProfileInfo = {
+type ProfileInfoProps = {
+  id: string,
   firstName: string;
   lastName: string;
   profileImageUrl: string;
@@ -33,48 +28,86 @@ function formatDate(date: Date) {
   const month = date.getUTCMonth() + 1; // Months are zero-indexed, so add 1
   const day = date.getUTCDate();
   const year = date.getUTCFullYear();
+
   // Format the date as MM/DD/YYYY
   const formattedDate = `${month.toString().padStart(2, '0')}/${day.toString().padStart(2, '0')}/${year}`;
-
   return formattedDate;
 }
 
-const updateProfile = async (values: ProfileInfo) => {
-  const response = await fetch('/api/v1/user/profile', {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(values),
-  });
+async function updateProfile (values: ProfileInfoProps): Promise<boolean> {
+  try {
+    const response = await fetch('/api/v1/user/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error.message);
+    const data = await response.json();
+    if (!response.ok || data.isError) {
+      throw new Error(data.message || 'Failed to update profile due to network request error.');
+    }
+    return true;
+  } catch (error) {
+    console.log('Profile update failed: ', error);
+    return false;
   }
-};
+}
 
 function ProfileInfo() {
-  const [initialValues, setInitialValues] = useState<ProfileInfo | null>(null);
+  const [initialValues, setInitialValues] = useState<ProfileInfoProps | null>(null);
   const [tags, setTags] = useState<TagInfo[]>([]);
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const toast = useToast();
+
+  const goToProfile = () => {
+    navigate(`/profile/${initialValues?.id}`);
+  };
+
+  const handleUpdateProfile = async (values: ProfileInfoProps) => {
+    setIsLoading(true);
+    const success = await updateProfile(values);
+    setIsLoading(false);
+
+    if (success) {
+      toast({
+        title: 'Profile succesfully updated!',
+        status: 'success',
+        duration: 2000,
+      });
+    } else {
+      toast({
+        title: 'Profile update failed.',
+        status: 'error',
+        duration: 2000,
+      });
+    }
+  };
 
   useEffect(() => {
-    fetch('/api/v1/user/profile', {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-      .then(response => response.json())
-      .then(({ data }) => {
-        setInitialValues({
-          ...data,
-          birthDate: formatDate(new Date(data.birthDate)),
+    const fetchProfile = async () => {
+      try {
+        const response = await fetch('/api/v1/user/profile', {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
         });
+
+        const { data } = await response.json();
+        setInitialValues({ ...data, birthDate: formatDate(new Date(data.birthDate)) });
         setTags(data.tags);
-      })
-      .catch(error => console.error(error));
-  }, []);
+        setIsLoading(false);
+      } catch (error) {
+        toast({
+          title: 'Failed to load profile data.',
+          description: 'Please refresh the page to try again.',
+          status: 'error',
+          duration: 2000,
+        });
+        setIsLoading(false);
+      }
+    };
+    fetchProfile();
+  }, [toast]);
 
   if (!initialValues) {
     return (
@@ -89,14 +122,12 @@ function ProfileInfo() {
       <Formik
         initialValues={initialValues}
         validationSchema={profileSchema}
-        onSubmit={values => updateProfile(values)}
+        onSubmit={handleUpdateProfile}
       >
         {formik => (
           <Form className="profile-form">
             <VStack gap={1} divider={<StackDivider/>} >
-              <Avatar className="avatar" border={'1px'} size={['lg', 'xl']} name={`${initialValues.firstName} ${initialValues.lastName}`} src={initialValues.profileImageUrl}>
-                {/* <AvatarBadge boxSize={'1em'} bg="brand.500" border={'1px'} >+</AvatarBadge> */}
-              </Avatar>
+              <Avatar className="avatar" border={'1px'} size={['lg', 'xl']} name={`${initialValues.firstName} ${initialValues.lastName}`} src={initialValues.profileImageUrl}></Avatar>
               <FormControl id={'email'} isInvalid={!!(formik.errors.email && formik.touched.email)}>
                 <FormLabel>Email</FormLabel>
                 <Field as={Input} name={'email'}></Field>
@@ -135,19 +166,38 @@ function ProfileInfo() {
                 <FormLabel>Interests</FormLabel>
                 <TagInput tags={tags} setTags={setTags} />
               </FormControl>
-              <Button
-                className="submit-button"
-                type="submit"
-                colorScheme="brand"
-                variant="outline"
-                _hover={{
-                  backgroundColor: 'brand.500',
-                  border: '1px solid transparent',
-                  color: 'white',
-                }}
-                disabled={!formik.dirty || formik.isSubmitting}>
-                                SAVE
-              </Button>
+              <Box display="flex" flexDirection="column" width="100%">
+                <Button
+                  className="submit-button"
+                  isLoading={isLoading}
+                  type="submit"
+                  colorScheme="brand"
+                  variant="outline"
+                  _hover={{
+                    backgroundColor: 'brand.500',
+                    border: '1px solid transparent',
+                    color: 'white',
+                  }}
+                  disabled={!formik.dirty || formik.isSubmitting}
+                >
+                SAVE
+                </Button>
+                <Button
+                  className="submit-button"
+                  onClick={goToProfile}
+                  colorScheme="brand"
+                  type="button"
+                  variant="outline"
+                  _hover={{
+                    backgroundColor: 'brand.500',
+                    border: '1px solid transparent',
+                    color: 'white',
+                  }}
+                >
+
+                SEE MY PROFILE
+                </Button>
+              </Box>
             </VStack>
           </Form>
         )}

--- a/apps/frontend/src/pages/profile/ProfileInfo.tsx
+++ b/apps/frontend/src/pages/profile/ProfileInfo.tsx
@@ -194,7 +194,6 @@ function ProfileInfo() {
                     color: 'white',
                   }}
                 >
-
                 SEE MY PROFILE
                 </Button>
               </Box>

--- a/apps/frontend/src/schemas/schemas.ts
+++ b/apps/frontend/src/schemas/schemas.ts
@@ -1,5 +1,11 @@
 import * as Yup from 'yup';
 
+export const updateProfileSchema = Yup.object({
+  firstName: Yup.string().required('First name is required.'),
+  lastName: Yup.string().required('Last name is required.'),
+  email: Yup.string().email('Invalid email address.').required('Email is required.'),
+});
+
 export const registrationSchema = Yup.object({
   firstName: Yup.string()
     .required('Please enter your first name.'),


### PR DESCRIPTION
### Summary
- Add a pop-up notification (`toast`) to the `AccountInfo` page

- Add a loading icon to the `Save` button

- Removed the password field from the `AccountInfo` page. From the user's perspective, the password field is a little confusing, since it's not entirely clear if (a) the password is updated or (b) the password's needed to confirm the changes (it's the latter).

- Added a new Formik schema for the `AccountInfo` page

- Added a pop-up notification (`toast`) to the `ProfileInfo` page

- Added a loading icon to the `Save` button

- Added a second button, `See My Profile`, to the `ProfileInfo` page, which redirects the user to their public-facing profile page. I chose this because the `Enter` key is required to add tags, but this also triggers the `Save` button, re-directing them to the other page after each added tag, which isn't ideal

### Testing

#### Account Page
1. Spin up resources: 
```
make res
npm run -w apps/frontend start:dev
npm run -w apps/api start:dev
``` 
2. Log in as one of the default users
3. Go to the account page
4. Update the first name and click `Save`. You may see the loading icon, but the operation's likely too fast; you should see a "Profile Successfully Updated!" message.
5. Refresh the page, then click on the Hamburger Menu; it should reflect the updated value*

#### Profile Page
1. Go the profile page
2. Click on the `SEE MY PROFILE` button; confirm that it navigates the user to their public-facing profile page
3. Update the bio and click `Save`. You may see the loading icon, but the operation's like too fast; you should see a "Profile Successfully Updated!" message.**

### Notes
- *Updating the Account Info requires a page refresh to see the changes in the Hamburger menu. For such info to be updated everywhere, we'd need to use global state.
- **The changes to the `ProfilePage` don't persist when going to the public-facing page. I'll fix this tomorrow, but it's bedtime right now!